### PR TITLE
fix: clarify expected type in RunQueryOperation

### DIFF
--- a/dal/db_manager.go
+++ b/dal/db_manager.go
@@ -82,7 +82,7 @@ func RunQueryOperation[T any](ctx context.Context, dbManager DatabaseManager, fn
 
 	typedResult, ok := result.(T)
 	if !ok {
-		return zero, fmt.Errorf("cannot cast result to %T", result, zero)
+		return zero, fmt.Errorf("cannot cast result to %T", zero)
 	}
 	return typedResult, nil
 }


### PR DESCRIPTION
## Summary
- fix RunQueryOperation error to display expected type when cast fails

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689909050dcc83328a0af7ba04b587d9