### PR TITLE
Refactor DB operations to use typed callbacks

### DIFF
--- a/services/department.go
+++ b/services/department.go
@@ -29,11 +29,7 @@ func NewDepartmentServiceImpl(dbManager dal.DatabaseManager, departmentWriteRepo
 }
 
 func (s *DepartmentServiceImpl) CreateDepartment(ctx context.Context, department models.Department) error {
-	return dal.RunExecOperation(ctx, s.dbManager, func(ctx context.Context, tx sqlx.ExtContext) (interface{}, error) {
-		err := s.departmentWriteRepository.CreateDepartment(ctx, tx, mappers.MapToDbDepartment(department))
-		if err != nil {
-			return nil, err
-		}
-		return nil, nil
+	return dal.RunExecOperation(ctx, s.dbManager, func(ctx context.Context, tx sqlx.ExtContext) error {
+		return s.departmentWriteRepository.CreateDepartment(ctx, tx, mappers.MapToDbDepartment(department))
 	}, false)
 }

--- a/services/user.go
+++ b/services/user.go
@@ -33,12 +33,12 @@ func NewUserServiceImpl(dbManager dal.DatabaseManager, userWriteRepository users
 }
 
 func (u *UserServiceImpl) CreateUser(ctx context.Context, userPassport models.UserPassport) (models.SuccessCreateUser, error) {
-	return dal.RunQueryOperation[models.SuccessCreateUser](ctx, u.dbManager, func(ctx context.Context, tx sqlx.ExtContext) (interface{}, error) {
+	return dal.RunQueryOperation[models.SuccessCreateUser](ctx, u.dbManager, func(ctx context.Context, tx sqlx.ExtContext) (models.SuccessCreateUser, error) {
 		dbUser := mappers.MapToDbUser(userPassport)
 		createdUser, err := u.userWriteRepository.CreateUser(ctx, tx, dbUser)
 		if err != nil {
 			u.logger.Error("Failed to create user", zap.Error(err))
-			return nil, err
+			return models.SuccessCreateUser{}, err
 		}
 
 		user := mappers.MapToDomainSuccessCreateUser(createdUser)
@@ -46,7 +46,7 @@ func (u *UserServiceImpl) CreateUser(ctx context.Context, userPassport models.Us
 		passport, err := u.passportWriteRepository.CreatePassport(ctx, tx, mappers.MapToDbPassport(userPassport, user.Id))
 		if err != nil {
 			u.logger.Error("Failed to create passport", zap.Error(err))
-			return nil, err
+			return models.SuccessCreateUser{}, err
 		}
 
 		user.Passport = mappers.MapToDomainPassport(passport)


### PR DESCRIPTION
## Summary
- simplify DatabaseManager by accepting typed exec functions
- expose typed RunQueryOperation and RunExecOperation helpers
- update services to use new function signatures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689908fd929883329b8371f42cdb695f